### PR TITLE
Expose option to set custom URDF in launch files

### DIFF
--- a/agimus_demo_00_franka_controller/launch/bringup.launch.py
+++ b/agimus_demo_00_franka_controller/launch/bringup.launch.py
@@ -1,18 +1,16 @@
 from launch import LaunchContext, LaunchDescription
 from launch.actions import (
-    IncludeLaunchDescription,
     OpaqueFunction,
 )
 from launch.launch_description_entity import LaunchDescriptionEntity
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
-    LaunchConfiguration,
     PathJoinSubstitution,
 )
 from launch_ros.substitutions import FindPackageShare
 
 from agimus_demos_common.launch_utils import (
     generate_default_franka_args,
+    generate_include_franka_launch,
 )
 
 
@@ -31,31 +29,12 @@ def launch_setup(
 
     joint_impedance_example_controller_names = ["joint_impedance_example_controller"]
 
-    franka_robot_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [
-                PathJoinSubstitution(
-                    [
-                        FindPackageShare("agimus_demos_common"),
-                        "launch",
-                        "franka_common.launch.py",
-                    ]
-                )
-            ]
-        ),
-        launch_arguments={
-            "external_controllers_names": str(joint_impedance_example_controller_names),
+    franka_robot_launch = generate_include_franka_launch(
+        "franka_common.launch.py",
+        extra_launch_arguments={
             "external_controllers_params": joint_impedance_example_controller_params,
-            "arm_id": LaunchConfiguration("arm_id"),
-            "aux_computer_ip": LaunchConfiguration("aux_computer_ip"),
-            "aux_computer_user": LaunchConfiguration("aux_computer_user"),
-            "on_aux_computer": LaunchConfiguration("on_aux_computer"),
-            "robot_ip": LaunchConfiguration("robot_ip"),
-            "use_gazebo": LaunchConfiguration("use_gazebo"),
-            "use_rviz": LaunchConfiguration("use_rviz"),
-            "gz_verbose": LaunchConfiguration("gz_verbose"),
-            "gz_headless": LaunchConfiguration("gz_headless"),
-        }.items(),
+            "external_controllers_names": str(joint_impedance_example_controller_names),
+        },
     )
 
     return [franka_robot_launch]

--- a/agimus_demos_common/README.md
+++ b/agimus_demos_common/README.md
@@ -33,6 +33,12 @@ Launch arguments specific to this launch file:
 
     Path to the yaml file use to define controller parameters.
 
+- **franka_description_path**:
+
+    Default: *franka_description/fer/fer.urdf.xacro*
+
+    Path to URDF file containing robot description.
+
 - **rviz_config_path**:
 
     Default: *agimus_demos_common/rviz/franka_preview.rviz*
@@ -137,7 +143,19 @@ def launch_setup(
     context: LaunchContext, *args, **kwargs
 ) -> list[LaunchDescriptionEntity]:
     # Helper function that includes `franka_common_lfc.launch.py`.
-    franka_robot_launch = generate_include_franka_launch("franka_common_lfc.launch.py")
+    # Pass custom URDF argument to the launch file.
+    franka_robot_launch = generate_include_franka_launch(
+        "franka_common_lfc.launch.py"
+        extra_launch_arguments={
+            "franka_description_path": PathJoinSubstitution(
+                [
+                    FindPackageShare("my_custom_description_package"),
+                    "urdf",
+                    "my_custom_robot.urdf.xacro",
+                ]
+            )
+        }
+    )
 
     # Utility ROS node, delaying stat of other nodes until
     # robot's position was initialized in the simulation.

--- a/agimus_demos_common/agimus_demos_common/launch_utils.py
+++ b/agimus_demos_common/agimus_demos_common/launch_utils.py
@@ -87,14 +87,19 @@ def generate_default_franka_args() -> list[DeclareLaunchArgument]:
     ]
 
 
-def generate_include_franka_launch(launch_file_name: str) -> IncludeLaunchDescription:
+def generate_include_franka_launch(
+    launch_file_name: str = "franka_common.launch.py",
+    extra_launch_arguments={},
+) -> IncludeLaunchDescription:
     """Generates IncludeLaunchDescription object of default launch files
         for Agimus Demos for Franka robots. Automatically obtains values of launch arguments required
         by the launch file. Assumes argument are declared with function `generate_default_franka_args()`.
 
     Args:
         launch_file_name (str): Name of the python launch file to included
-            from directory `agimus_demos_common/launch`.
+            from directory `agimus_demos_common/launch`. Defaults to `franka_common.launch.py`.
+        extra_launch_arguments (dict, optional): Dictionary with extra launch arguments passed to
+            the launch file. Defaults to {}.
 
     Returns:
         IncludeLaunchDescription: Include launch description with all default parameters passed to it.
@@ -105,6 +110,7 @@ def generate_include_franka_launch(launch_file_name: str) -> IncludeLaunchDescri
             f"Incorrect launch file name! '{launch_file_name}' is not part of public API "
             + f"launch files of Agimus Demos! Allowed options are {public_launch_files}!"
         )
+
     return IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
@@ -127,6 +133,7 @@ def generate_include_franka_launch(launch_file_name: str) -> IncludeLaunchDescri
             "use_rviz": LaunchConfiguration("use_rviz"),
             "gz_verbose": LaunchConfiguration("gz_verbose"),
             "gz_headless": LaunchConfiguration("gz_headless"),
+            **extra_launch_arguments,
         }.items(),
     )
 

--- a/agimus_demos_common/launch/franka_common.launch.py
+++ b/agimus_demos_common/launch/franka_common.launch.py
@@ -45,6 +45,7 @@ def launch_setup(
     external_controllers_params = LaunchConfiguration("external_controllers_params")
     external_controllers_names = LaunchConfiguration("external_controllers_names")
     franka_controllers_params = LaunchConfiguration("franka_controllers_params")
+    franka_description_path = LaunchConfiguration("franka_description_path")
     use_rviz = LaunchConfiguration("use_rviz")
     rviz_config_path = LaunchConfiguration("rviz_config_path")
     gz_verbose = LaunchConfiguration("gz_verbose")
@@ -249,20 +250,13 @@ def launch_setup(
         "with_sc": "false",
         "franka_controllers_params": franka_controllers_params,
     }
-    robot_description_file_substitution = PathJoinSubstitution(
-        [
-            FindPackageShare("franka_description"),
-            "robots",
-            arm_id_str,
-            f"{arm_id_str}.urdf.xacro",
-        ]
-    )
+
     robot_description = ParameterValue(
         Command(
             [
                 PathJoinSubstitution([FindExecutable(name="xacro")]),
                 " ",
-                robot_description_file_substitution,
+                franka_description_path,
                 # Convert dict to list of parameters
                 *[arg for key, val in xacro_args.items() for arg in (f" {key}:=", val)],
             ]
@@ -279,7 +273,7 @@ def launch_setup(
             [
                 PathJoinSubstitution([FindExecutable(name="xacro")]),
                 " ",
-                robot_description_file_substitution,
+                franka_description_path,
                 # Convert dict to list of parameters
                 *[
                     arg
@@ -394,6 +388,18 @@ def generate_launch_description():
                 ]
             ),
             description="Path to the yaml file use to define controller parameters.",
+        ),
+        DeclareLaunchArgument(
+            "franka_description_path",
+            default_value=PathJoinSubstitution(
+                [
+                    FindPackageShare("franka_description"),
+                    "robots",
+                    "fer",
+                    "fer.urdf.xacro",
+                ]
+            ),
+            description="Path to URDF file containing robot description.",
         ),
         DeclareLaunchArgument(
             "rviz_config_path",

--- a/agimus_demos_common/launch/franka_common_lfc.launch.py
+++ b/agimus_demos_common/launch/franka_common_lfc.launch.py
@@ -1,11 +1,9 @@
 from launch import LaunchContext, LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
-    IncludeLaunchDescription,
     OpaqueFunction,
 )
 from launch.launch_description_entity import LaunchDescriptionEntity
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
     LaunchConfiguration,
     PathJoinSubstitution,
@@ -14,6 +12,7 @@ from launch_ros.substitutions import FindPackageShare
 
 from agimus_demos_common.launch_utils import (
     generate_default_franka_args,
+    generate_include_franka_launch,
 )
 
 
@@ -25,24 +24,9 @@ def launch_setup(
         "joint_state_estimator",
     ]
 
-    franka_robot_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [
-                PathJoinSubstitution(
-                    [
-                        FindPackageShare("agimus_demos_common"),
-                        "launch",
-                        "franka_common.launch.py",
-                    ]
-                )
-            ]
-        ),
-        launch_arguments={
-            "arm_id": LaunchConfiguration("arm_id"),
-            "aux_computer_ip": LaunchConfiguration("aux_computer_ip"),
-            "aux_computer_user": LaunchConfiguration("aux_computer_user"),
-            "on_aux_computer": LaunchConfiguration("on_aux_computer"),
-            "robot_ip": LaunchConfiguration("robot_ip"),
+    franka_robot_launch = generate_include_franka_launch(
+        "franka_common.launch.py",
+        extra_launch_arguments={
             "external_controllers_params": LaunchConfiguration(
                 "linear_feedback_controller_params"
             ),
@@ -50,12 +34,8 @@ def launch_setup(
             "franka_controllers_params": LaunchConfiguration(
                 "franka_controllers_params"
             ),
-            "use_gazebo": LaunchConfiguration("use_gazebo"),
-            "use_rviz": LaunchConfiguration("use_rviz"),
-            "rviz_config_path": LaunchConfiguration("rviz_config_path"),
-            "gz_verbose": LaunchConfiguration("gz_verbose"),
-            "gz_headless": LaunchConfiguration("gz_headless"),
-        }.items(),
+            "franka_description_path": LaunchConfiguration("franka_description_path"),
+        },
     )
 
     return [franka_robot_launch]
@@ -85,6 +65,18 @@ def generate_launch_description():
             ),
             description="Path to the yaml file use to define "
             + "Linear Feedback Controller's and Joint State Estimator's params.",
+        ),
+        DeclareLaunchArgument(
+            "franka_description_path",
+            default_value=PathJoinSubstitution(
+                [
+                    FindPackageShare("franka_description"),
+                    "robots",
+                    "fer",
+                    "fer.urdf.xacro",
+                ]
+            ),
+            description="Path to URDF file containing robot description.",
         ),
         DeclareLaunchArgument(
             "rviz_config_path",


### PR DESCRIPTION
As per request of @MedericFourmy this PR implements option to set custom URDF files for demos. The URDF defaults to `franka_description/robots/fer.urdf.xacro`, but should be now easy to replace with any URDF.

This PR exposes new way to pass the argument as:
```python
franka_robot_launch = generate_include_franka_launch(
    "franka_common_lfc.launch.py"
    extra_launch_arguments={
        "franka_description_path": PathJoinSubstitution(
            [
                FindPackageShare("my_custom_description_package"),
                "urdf",
                "my_custom_robot.urdf.xacro",
            ]
        )
    }
)
```