### PR TITLE
Fixed robot_attachment_frame for franka demo 03.

### DIFF
--- a/agimus_demo_03_mpc_dummy_traj/config/agimus_controller_params.yaml
+++ b/agimus_demo_03_mpc_dummy_traj/config/agimus_controller_params.yaml
@@ -22,3 +22,4 @@ agimus_controller_node:
     cp_1:
       first: fer_hand_sc_capsule_0
       second: obstacle1_capsule_0
+    robot_attachment_frame: universe


### PR DESCRIPTION
Due to code change in agimus_controller/robot_model.py, the robot_attachement_frame: universe must be configured for demo_03.

Not sure, but maybe the same should be updated for tiago.